### PR TITLE
Add adb device action to copy screenshot to clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "android",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.39.0",
+        "@raycast/api": "^1.47.0",
         "expand-tilde": "^2.0.2"
       },
       "devDependencies": {
@@ -208,18 +208,30 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.39.1.tgz",
-      "integrity": "sha512-YvQr3DWE6bGVxgqWBrnF/0NtY5cUSeOc3W1S1fkgA5j6xu7gBZfHOwTPbmsoINnnPuxR/nW/DSE14e5arjQJzg==",
+      "version": "1.47.3",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.47.3.tgz",
+      "integrity": "sha512-Oy0yhwvOdeiVDIVYGJwBxHVWWtZm5skpoZVGpdBZBL7gkBMBAdkDDZ/v4SsSUBBELWuX7AQ4WLlTzr8BrWqKvA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/node": "16.10.3",
+        "@types/node": "18.8.3",
         "@types/react": "18.0.9",
         "react": "18.1.0",
         "react-reconciler": "0.28.0"
       },
       "bin": {
         "ray": "bin/ray"
+      },
+      "peerDependencies": {
+        "@types/node": "18.8.3",
+        "@types/react": "18.0.9"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/json-schema": {
@@ -229,9 +241,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ=="
+      "version": "18.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
+      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -2825,11 +2837,11 @@
       }
     },
     "@raycast/api": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.39.1.tgz",
-      "integrity": "sha512-YvQr3DWE6bGVxgqWBrnF/0NtY5cUSeOc3W1S1fkgA5j6xu7gBZfHOwTPbmsoINnnPuxR/nW/DSE14e5arjQJzg==",
+      "version": "1.47.3",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.47.3.tgz",
+      "integrity": "sha512-Oy0yhwvOdeiVDIVYGJwBxHVWWtZm5skpoZVGpdBZBL7gkBMBAdkDDZ/v4SsSUBBELWuX7AQ4WLlTzr8BrWqKvA==",
       "requires": {
-        "@types/node": "16.10.3",
+        "@types/node": "18.8.3",
         "@types/react": "18.0.9",
         "react": "18.1.0",
         "react-reconciler": "0.28.0"
@@ -2842,9 +2854,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ=="
+      "version": "18.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
+      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w=="
     },
     "@types/prop-types": {
       "version": "15.7.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.39.0",
+    "@raycast/api": "^1.47.0",
     "expand-tilde": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
       "description": "show android emulators",
       "icon": "list-android.png",
       "mode": "view"
+    },
+    {
+      "name": "adb-devices",
+      "title": "List ADB Devices",
+      "subtitle": "Android",
+      "description": "show connected android devices",
+      "icon": "list-android.png",
+      "mode": "view"
     }
   ],
   "preferences": [

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -17,6 +17,11 @@ export function emulatorPath(): string {
   return `${androidSDK()}/emulator/emulator`;
 }
 
+
+export function adbPath(): string {
+  return `${androidSDK()}/platform-tools/adb`;
+}
+
 export function androidSDK() {
   const expandTilde = require("expand-tilde");
   const sdk = getPreferenceValues().androidSDK;

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -65,3 +65,18 @@ export function runCommand(
     error(data.toString());
   });
 }
+
+export async function runCommandAsync(cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn(cmd, [], { shell: true });
+    childProcess.stdout.on("data", function (data: string) {
+      resolve(data.toString());
+      console.log("stdout: " + data);
+    });
+  
+    childProcess.stderr.on("data", function (data: string) {
+      console.log("stderr: " + data);
+      reject(data.toString());
+    });
+  });
+}

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -1,0 +1,108 @@
+import {
+  Action,
+  ActionPanel,
+  Icon,
+  List,
+  popToRoot,
+  showToast,
+  Toast,
+} from "@raycast/api";
+import { useEffect, useState } from "react";
+import {
+  adbPath,
+  androidSDK,
+  emulatorPath,
+  isAndroidStudioInstalled,
+  isValidDirectory,
+  runCommand,
+} from "./Utils";
+
+export default function Command() {
+  const [items, setItems] = useState<string[]>(() => []);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function listDevices() {
+      if (!isAndroidStudioInstalled()) {
+        showToast(Toast.Style.Failure, "Android studio is not installed");
+        setLoading(false);
+        return;
+      }
+
+      if (!isValidDirectory(androidSDK())) {
+        showToast(Toast.Style.Failure, "Invalid Android SDK directory!!");
+        setLoading(false);
+        return;
+      }
+
+      const command = `${adbPath()} devices`;
+      console.log(command);
+      runCommand(
+        command,
+        (data) => {
+          if (data != null) {
+            const avds = (data + "")
+              .split("\n")
+              .filter((p: string) => p != "List of devices attached")
+              .map((p: string) => p.split("\t")[0])
+              .filter((p: string) => p.trim());
+            setItems(avds);
+          }
+
+          setLoading(false);
+        },
+        (err) => {
+          showToast(Toast.Style.Failure, err);
+          setLoading(false);
+        }
+      );
+    }
+
+    listDevices();
+  }, []);
+
+  return (
+    <List isLoading={loading}>
+      {items?.map((emulator: string, index) => (
+        <List.Item
+          icon={{ source: "android-emulator.png" }}
+          key={index}
+          title={emulator}
+          accessories={[{ icon: Icon.Mobile }]}
+          actions={
+            <ActionPanel>
+              <Action
+                title="Open Emulator"
+                onAction={() => openEmultror(emulator)}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
+}
+
+function openEmultror(emulator: string): void {
+  runCommand(
+    `${emulatorPath()} -no-audio -no-snapshot-save -no-snapshot-load @${emulator}`,
+    (data) => {
+      popToRoot;
+    },
+    (error) => {
+      showToast(Toast.Style.Failure, error);
+    }
+  );
+}
+
+function takeScreenshot(emulatorId: string): void {
+  runCommand(
+    `${adbPath()} -s ${emulatorId} exec-out screencap -p > /tmp/raycast-screenshot-${emulatorId}.png`,
+    (data) => {
+      popToRoot;
+    },
+    (error) => {
+      showToast(Toast.Style.Failure, error);
+    }
+  );
+}

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -74,7 +74,7 @@ export default function Command() {
             <ActionPanel>
               <Action
                 title="Save Screenshot"
-                onAction={() => copyScreenshot(emulator)}
+                onAction={() => saveScreenshot(emulator)}
               />
             </ActionPanel>
           }
@@ -84,11 +84,12 @@ export default function Command() {
   );
 }
 
-async function copyScreenshot(emulatorId: string) {
+async function saveScreenshot(emulatorId: string) {
+  const expandTilde = require("expand-tilde");
   const command =`
     set -e
     name="Screenshot_$(date "+%d:%b:%y_%H:%M:%S")"
-    file="/tmp/$name.png"
+    file="${expandTilde("~")}/Desktop/$name.png"
     ${adbPath()} -s ${emulatorId} exec-out screencap -p > $file
     echo $file
   `; 

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -3,7 +3,7 @@ import {
   ActionPanel,
   Icon,
   List,
-  popToRoot,
+  closeMainWindow,
   showToast,
   Toast,
   Clipboard
@@ -94,21 +94,21 @@ async function saveScreenshot(emulatorId: string) {
     echo $file
   `;
   
-  showToast(Toast.Style.Animated, "Taking a screenshot");
+  showToast(Toast.Style.Animated, "Copying the screenshot");
   await runCommandAsync(command)
     .then((filePath) => {
       copyScreenshot(filePath.trim())
-      showToast(Toast.Style.Success, "Copied to clipboard");
+      showToast(Toast.Style.Success, "Done");
     })
     .catch((err) => {
       showToast(Toast.Style.Failure, err);
     })
     .finally(() => {
-      popToRoot;
+      closeMainWindow();
     });
 }
 
-async function copyScreenshot(filePath:string){
+async function copyScreenshot(filePath: string){
   const content: Clipboard.Content = { "file": filePath }
   await Clipboard.copy(content)
 }

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -15,6 +15,7 @@ import {
   isAndroidStudioInstalled,
   isValidDirectory,
   runCommand,
+  runCommandAsync,
 } from "./Utils";
 
 export default function Command() {
@@ -83,7 +84,7 @@ export default function Command() {
   );
 }
 
-function copyScreenshot(emulatorId: string): void {
+async function copyScreenshot(emulatorId: string) {
   const command =`
     set -e
     name="Screenshot_$(date "+%d:%b:%y_%H:%M:%S")"
@@ -91,14 +92,14 @@ function copyScreenshot(emulatorId: string): void {
     ${adbPath()} -s ${emulatorId} exec-out screencap -p > $file
     echo $file
   `; 
-  runCommand(
-    command,
-    (data) => {
-      showToast(Toast.Style.Success, data);
+  await runCommandAsync(command)
+    .then((value) => {
+      showToast(Toast.Style.Success, value);
+    })
+    .catch((err) => {
+      showToast(Toast.Style.Failure, err);
+    })
+    .finally(() => {
       popToRoot;
-    },
-    (error) => {
-      showToast(Toast.Style.Failure, error);
-    }
-  );
+    });
 }

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -72,8 +72,8 @@ export default function Command() {
           actions={
             <ActionPanel>
               <Action
-                title="Open Emulator"
-                onAction={() => openEmultror(emulator)}
+                title="Save Screenshot"
+                onAction={() => copyScreenshot(emulator)}
               />
             </ActionPanel>
           }
@@ -83,22 +83,18 @@ export default function Command() {
   );
 }
 
-function openEmultror(emulator: string): void {
+function copyScreenshot(emulatorId: string): void {
+  const command =`
+    set -e
+    name="Screenshot_$(date "+%d:%b:%y_%H:%M:%S")"
+    file="/tmp/$name.png"
+    ${adbPath()} -s ${emulatorId} exec-out screencap -p > $file
+    echo $file
+  `; 
   runCommand(
-    `${emulatorPath()} -no-audio -no-snapshot-save -no-snapshot-load @${emulator}`,
+    command,
     (data) => {
-      popToRoot;
-    },
-    (error) => {
-      showToast(Toast.Style.Failure, error);
-    }
-  );
-}
-
-function takeScreenshot(emulatorId: string): void {
-  runCommand(
-    `${adbPath()} -s ${emulatorId} exec-out screencap -p > /tmp/raycast-screenshot-${emulatorId}.png`,
-    (data) => {
+      showToast(Toast.Style.Success, data);
       popToRoot;
     },
     (error) => {

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -74,7 +74,7 @@ export default function Command() {
             <ActionPanel>
               <Action
                 title="Save Screenshot"
-                onAction={() => saveScreenshot(emulator)}
+                onAction={() => saveScreenshot(emulator, setLoading)}
               />
             </ActionPanel>
           }
@@ -84,15 +84,17 @@ export default function Command() {
   );
 }
 
-async function saveScreenshot(emulatorId: string) {
+async function saveScreenshot(emulatorId: string, setLoading: React.Dispatch<React.SetStateAction<boolean>>) {
   const expandTilde = require("expand-tilde");
   const command =`
     set -e
-    name="Screenshot_$(date "+%d:%b:%y_%H:%M:%S")"
+    name="Screenshot_$(date "+%d%b%y_%H%M%S").png"
     file="${expandTilde("~")}/Desktop/$name.png"
     ${adbPath()} -s ${emulatorId} exec-out screencap -p > $file
-    echo $file
-  `; 
+    echo $name
+  `;
+  
+  setLoading(true)
   await runCommandAsync(command)
     .then((value) => {
       showToast(Toast.Style.Success, value);
@@ -101,6 +103,7 @@ async function saveScreenshot(emulatorId: string) {
       showToast(Toast.Style.Failure, err);
     })
     .finally(() => {
+      setLoading(false)
       popToRoot;
     });
 }

--- a/src/adb-devices.tsx
+++ b/src/adb-devices.tsx
@@ -12,12 +12,12 @@ import { useEffect, useState } from "react";
 import {
   adbPath,
   androidSDK,
-  emulatorPath,
   isAndroidStudioInstalled,
   isValidDirectory,
   runCommand,
   runCommandAsync,
 } from "./Utils";
+import { tmpdir } from "os";
 
 export default function Command() {
   const [items, setItems] = useState<string[]>(() => []);
@@ -86,11 +86,10 @@ export default function Command() {
 }
 
 async function saveScreenshot(emulatorId: string) {
-  const expandTilde = require("expand-tilde");
   const command =`
     set -e
     name="Screenshot_$(date "+%d%b%y_%H%M%S").png"
-    file="${expandTilde("~")}/Desktop/$name"
+    file="${tmpdir()}/$name"
     ${adbPath()} -s ${emulatorId} exec-out screencap -p > $file
     echo $file
   `;


### PR DESCRIPTION
- List adb devices
- Save screenshot to temp dir
- Add runCommandAsync function to utilise promise
- Save screenshot to desktop
- Update raycast package version to 1.47
- Added loading and updated screenshot name
- Add copy functionality
- Update screenshot location to tmp dir
- Close raycast once screenshot is copied
